### PR TITLE
Update 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: f3bd36cd261b440a88a1190b1becca0578fee90b4b62decc796932fdd5ae8839
 
 build:
-  skip: True  # [py<38]
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install --no-deps . -vv
 
@@ -43,7 +43,7 @@ about:
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  dev_url: https://installer.pypa.io/en/stable/
+  dev_url: https://installer.pypa.io
   doc_url: https://github.com/pypa/installer/tree/main/docs
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-installer" %}
 {% set pypi_name = "installer" %}
-{% set version = "0.5.1" %}
+{% set version = "0.6.0" %}
 
 
 package:
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
-  sha256: f970995ec2bb815e2fdaf7977b26b2091e1e386f0f42eafd5ac811953dc5d445
+  sha256: f3bd36cd261b440a88a1190b1becca0578fee90b4b62decc796932fdd5ae8839
 
 build:
   skip: True  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,9 @@ source:
   sha256: f3bd36cd261b440a88a1190b1becca0578fee90b4b62decc796932fdd5ae8839
 
 build:
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install --no-deps . -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - setuptools
     - wheel
-    - flit-core >=3.2.0,<4
+    - flit-core 3.8.0
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ about:
   license: MIT
   license_file: LICENSE
   license_family: MIT
-  dev_url: https://installer.readthedocs.io/en/stable/
+  dev_url: https://installer.pypa.io/en/stable/
   doc_url: https://github.com/pypa/installer/tree/main/docs
 
 extra:


### PR DESCRIPTION
### Updating to `0.6.0` to accommodate the current version of `poetry`

[Upstream](https://github.com/pypa/installer)
[Changelog](https://installer.pypa.io/en/stable/changelog/)

### Actions
- Update version number and sha256
- Update python version skip to `<38`
- Add `--no-deps` to build script
- Change host section dependencies to exact pinnings
- Update `dev_url`