### PR TITLE
python-installer 0.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-installer" %}
 {% set pypi_name = "installer" %}
-{% set version = "0.7.0" %}
+{% set version = "0.6.0" %}
 
 
 package:
@@ -8,29 +8,33 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
-  sha256: a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631
+  url: https://pypi.org/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
+  sha256: f3bd36cd261b440a88a1190b1becca0578fee90b4b62decc796932fdd5ae8839
 
 build:
-  noarch: python
-  number: 1
+  number: 0
+  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - flit-core >=3.2.0,<4
   run:
-    - python >=3.7
+    - python
 
 test:
-  requires:
-    - pip
+  source_files:
+    - tests
   imports:
     - installer
+  requires:
+    - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/pypa/installer


### PR DESCRIPTION
python-installer 0.6.0

**Destination channel:** Defaults

### Links

- [PKG-9714](https://anaconda.atlassian.net/browse/PKG-9714)
- dev_url:        https://github.com/pypa/installer/tree/0.6.0
- conda_forge:    https://github.com/conda-forge/python-installer-feedstock
- pypi:           https://pypi.org/project/installer/0.6.0
- pypi inspector: https://inspector.pypi.io/project/installer/0.6.0

### Explanation of changes:

- backport to deploy older version for 3.13


[PKG-9714]: https://anaconda.atlassian.net/browse/PKG-9714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ