### PR TITLE
Update to 1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-installer" %}
 {% set pypi_name = "installer" %}
-{% set version = "0.7.0" %}
+{% set version = "1.0.0" %}
 
 
 package:
@@ -9,20 +9,20 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
-  sha256: a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631
+  sha256: c6d691331621cf3fec4822f5c6f83cab3705f79b316225dc454127411677c71f
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python >=3.10
     - flit-core >=3.2.0,<4
   run:
-    - python >=3.7
+    - python >=3.10
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   host:
     - pip
     - python >=3.10
-    - flit-core >=3.2.0,<4
+    - flit-core >=3.11.0,<4
   run:
     - python >=3.10
 


### PR DESCRIPTION
python-installer 1.0.0

**Destination channel:** defaults

### Links

- [pypa/installer 1.0.0 release](https://github.com/pypa/installer/releases/tag/1.0.0)
- [pypa/installer 0.7.0...1.0.0 diff](https://github.com/pypa/installer/compare/0.7.0...1.0.0)
- [pypa/installer 1.0.0 `pyproject.toml`](https://github.com/pypa/installer/blob/1.0.0/pyproject.toml)
- Relevant dependency PRs:
  - AnacondaRecipes/conda-pypi-feedstock#10 — consumer PR that pins `python-installer >=1.0` (blocked on this one)
  - conda-forge/conda-pypi-feedstock#42 — companion pin on conda-forge

### Explanation of changes:

- Bump version 0.7.0 → 1.0.0, refresh sha256 from the PyPI sdist.
- Raise `python >=3.7` → `python >=3.10` in host + run, to match installer 1.0.0's `requires-python = ">=3.10"`.
- Reset the build number to 0 for the new version.

### Motivation

`installer` 1.0.0 added `overwrite_existing` to `SchemeDictionaryDestination` (via the dataclass rewrite). `conda-pypi` 0.7.1 depends on that parameter in [`conda_pypi/installer.py`](https://github.com/conda/conda-pypi/blob/0.7.1/conda_pypi/installer.py#L52), so its `pyproject.toml` declares `python-installer >=1.0`. As long as `pkgs/main` only ships `python-installer` 0.7.0, any `conda pypi convert` call on defaults blows up with:

```
TypeError: SchemeDictionaryDestination.__init__() got an unexpected keyword argument 'overwrite_existing'
```

This is currently breaking conda's CI on every defaults matrix leg (e.g. `tests/test_create.py::test_dont_remove_conda_3`). Publishing `python-installer` 1.0.0 to `pkgs/main` is the prerequisite for AnacondaRecipes/conda-pypi-feedstock#10.